### PR TITLE
Fix initaliziation of minimum and maximum dates in dateinput.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
     up and cause an error in jquery 1.8.
     [davisagli]
 
+  - Fix initaliziation of minimum and maximum dates in dateinput.
+    [msom]
+
 
 # 1.2.7
 ### In Progress

--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -211,9 +211,8 @@
 		
 		// use sane values for value, min & max		
 		value = parseDate(value) || now;  
-		
-		min   = parseDate(min || new Date(yearNow + conf.yearRange[0], 1, 1));
-		max   = parseDate(max || new Date( yearNow + conf.yearRange[1]+ 1, 1, -1));
+		min   = parseDate(min || new Date(yearNow + conf.yearRange[0], 0, 1));
+		max   = parseDate(max || new Date(yearNow + conf.yearRange[1]+ 1, 0, 0));
 		
 		
 		// check that language exists


### PR DESCRIPTION
The month parameter ranges from 0...11 (not 1..12), the day parameter from 1...31 (that means that 0 is the last day of the previous month, not -1).